### PR TITLE
Support to different encodings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.1</version>
+                <configuration>
+                    <!-- workaround due to jdk bug -->
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/pl/jalokim/propertiestojson/Constants.java
+++ b/src/main/java/pl/jalokim/propertiestojson/Constants.java
@@ -2,6 +2,9 @@ package pl.jalokim.propertiestojson;
 
 public class Constants {
 
+    private Constants() {
+    }
+
     public static final String NORMAL_DOT = ".";
     public static final String REGEX_DOT = "\\.";
     public static final String EMPTY_STRING = "";

--- a/src/main/java/pl/jalokim/propertiestojson/JsonObjectFieldsValidator.java
+++ b/src/main/java/pl/jalokim/propertiestojson/JsonObjectFieldsValidator.java
@@ -1,24 +1,22 @@
 package pl.jalokim.propertiestojson;
 
-import pl.jalokim.propertiestojson.object.AbstractJsonType;
-import pl.jalokim.propertiestojson.object.ArrayJsonType;
-import pl.jalokim.propertiestojson.object.JsonNullReferenceType;
-import pl.jalokim.propertiestojson.object.MergableObject;
-import pl.jalokim.propertiestojson.object.ObjectJsonType;
-import pl.jalokim.propertiestojson.object.PrimitiveJsonType;
+import pl.jalokim.propertiestojson.object.*;
 import pl.jalokim.propertiestojson.path.PathMetadata;
 import pl.jalokim.propertiestojson.util.exception.CannotOverrideFieldException;
 
 public class JsonObjectFieldsValidator {
 
+    private JsonObjectFieldsValidator() {
+    }
+
     public static void checkThatFieldCanBeSet(ObjectJsonType currentObjectJson, PathMetadata currentPathMetaData, String propertyKey) {
-        if(currentObjectJson.containsField(currentPathMetaData.getFieldName())) {
+        if (currentObjectJson.containsField(currentPathMetaData.getFieldName())) {
             AbstractJsonType abstractJsonType = currentObjectJson.getField(currentPathMetaData.getFieldName());
-            if(currentPathMetaData.isArrayField()) {
-                if(isArrayJson(abstractJsonType)) {
+            if (currentPathMetaData.isArrayField()) {
+                if (isArrayJson(abstractJsonType)) {
                     ArrayJsonType jsonArray = currentObjectJson.getJsonArray(currentPathMetaData.getFieldName());
                     AbstractJsonType elementByDimArray = jsonArray.getElementByGivenDimIndexes(currentPathMetaData);
-                    if(elementByDimArray != null) {
+                    if (elementByDimArray != null) {
                         throwErrorWhenCannotMerge(currentPathMetaData, propertyKey, elementByDimArray);
                     }
                 } else {
@@ -31,15 +29,15 @@ public class JsonObjectFieldsValidator {
     }
 
     private static void throwErrorWhenCannotMerge(PathMetadata currentPathMetaData, String propertyKey, AbstractJsonType oldJsonValue) {
-        if (!isMergableJsonType(oldJsonValue) ) {
+        if (!isMergableJsonType(oldJsonValue)) {
             throw new CannotOverrideFieldException(currentPathMetaData.getCurrentFullPath(), oldJsonValue, propertyKey);
         }
     }
 
     public static void checkEarlierWasJsonObject(String propertyKey, PathMetadata currentPathMetaData, AbstractJsonType jsonType) {
-         if (!isObjectJson(jsonType)) {
-             throw new CannotOverrideFieldException(currentPathMetaData.getCurrentFullPath(), jsonType, propertyKey);
-         }
+        if (!isObjectJson(jsonType)) {
+            throw new CannotOverrideFieldException(currentPathMetaData.getCurrentFullPath(), jsonType, propertyKey);
+        }
     }
 
     public static boolean isObjectJson(AbstractJsonType jsonType) {

--- a/src/main/java/pl/jalokim/propertiestojson/JsonObjectsTraverseResolver.java
+++ b/src/main/java/pl/jalokim/propertiestojson/JsonObjectsTraverseResolver.java
@@ -33,10 +33,9 @@ public class JsonObjectsTraverseResolver {
     public void initializeFieldsInJson() {
         PathMetadata currentPathMetaData = rootPathMetaData;
         Object valueFromProperties = properties.get(currentPathMetaData.getOriginalPropertyKey());
-        if(valueFromProperties != null) {
-            if(valueFromProperties instanceof SkipJsonField) {
-                return;
-            }
+        if (valueFromProperties instanceof SkipJsonField) {
+            return;
+
         }
         AbstractJsonType resolverJsonObject = primitiveJsonTypesResolver.resolvePrimitiveTypeAndReturn(valueFromProperties, currentPathMetaData.getOriginalPropertyKey());
         if (resolverJsonObject instanceof SkipJsonField && !rootPathMetaData.getLeaf().isArrayField()) {
@@ -46,19 +45,19 @@ public class JsonObjectsTraverseResolver {
         }
         rootPathMetaData.getLeaf().setRawValue(properties.get(propertyKey));
 
-        while(currentPathMetaData != null) {
+        while (currentPathMetaData != null) {
             DataForResolve dataForResolve = new DataForResolve(properties, propertyKey, currentObjectJsonType, currentPathMetaData);
             currentObjectJsonType = algorithms.get(resolveAlgorithm(currentPathMetaData))
-                                              .traverseOnObjectAndInitByField(dataForResolve);
+                    .traverseOnObjectAndInitByField(dataForResolve);
             currentPathMetaData = currentPathMetaData.getChild();
         }
     }
 
     private AlgorithmType resolveAlgorithm(PathMetadata currentPathMetaData) {
-        if(isPrimitiveField(currentPathMetaData)) {
+        if (isPrimitiveField(currentPathMetaData)) {
             return AlgorithmType.PRIMITIVE;
         }
-        if(currentPathMetaData.isArrayField()) {
+        if (currentPathMetaData.isArrayField()) {
             return AlgorithmType.ARRAY;
         }
         return AlgorithmType.OBJECT;

--- a/src/main/java/pl/jalokim/propertiestojson/exception/NotLeafValueException.java
+++ b/src/main/java/pl/jalokim/propertiestojson/exception/NotLeafValueException.java
@@ -1,0 +1,8 @@
+package pl.jalokim.propertiestojson.exception;
+
+public class NotLeafValueException extends RuntimeException {
+
+    public NotLeafValueException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/pl/jalokim/propertiestojson/object/JsonNullReferenceType.java
+++ b/src/main/java/pl/jalokim/propertiestojson/object/JsonNullReferenceType.java
@@ -11,9 +11,9 @@ import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToConcreteObj
  */
 public final class JsonNullReferenceType extends AbstractJsonType {
 
-    public final static JsonNullReferenceType NULL_OBJECT = new JsonNullReferenceType();
+    public static final JsonNullReferenceType NULL_OBJECT = new JsonNullReferenceType();
 
-    public final static String NULL_VALUE = "null";
+    public static final String NULL_VALUE = "null";
 
     @Override
     public String toStringJson() {

--- a/src/main/java/pl/jalokim/propertiestojson/object/ObjectJsonType.java
+++ b/src/main/java/pl/jalokim/propertiestojson/object/ObjectJsonType.java
@@ -7,10 +7,7 @@ import pl.jalokim.propertiestojson.util.exception.CannotOverrideFieldException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static pl.jalokim.propertiestojson.Constants.EMPTY_STRING;
-import static pl.jalokim.propertiestojson.Constants.JSON_OBJECT_END;
-import static pl.jalokim.propertiestojson.Constants.JSON_OBJECT_START;
-import static pl.jalokim.propertiestojson.Constants.NEW_LINE_SIGN;
+import static pl.jalokim.propertiestojson.Constants.*;
 import static pl.jalokim.propertiestojson.object.MergableObject.mergeObjectIfPossible;
 import static pl.jalokim.utils.collection.CollectionUtils.getLastIndex;
 
@@ -19,18 +16,18 @@ public class ObjectJsonType extends AbstractJsonType implements MergableObject<O
     private Map<String, AbstractJsonType> fields = new HashMap<>();
 
     public void addField(final String field, final AbstractJsonType object, PathMetadata currentPathMetaData) {
-        if(object instanceof SkipJsonField) {
+        if (object instanceof SkipJsonField) {
             return;
         }
 
         AbstractJsonType oldFieldValue = fields.get(field);
-        if(oldFieldValue != null) {
-            if(oldFieldValue instanceof MergableObject && object instanceof MergableObject) {
+        if (oldFieldValue != null) {
+            if (oldFieldValue instanceof MergableObject && object instanceof MergableObject) {
                 mergeObjectIfPossible(oldFieldValue, object, currentPathMetaData);
             } else {
                 throw new CannotOverrideFieldException(currentPathMetaData.getCurrentFullPath(),
-                                                       oldFieldValue,
-                                                       currentPathMetaData.getOriginalPropertyKey());
+                        oldFieldValue,
+                        currentPathMetaData.getOriginalPropertyKey());
             }
         } else {
             fields.put(field, object);
@@ -54,13 +51,13 @@ public class ObjectJsonType extends AbstractJsonType implements MergableObject<O
         StringBuilder result = new StringBuilder().append(JSON_OBJECT_START);
         int index = 0;
         int lastIndex = getLastIndex(fields.keySet());
-        for(String fieldName : fields.keySet()) {
-            AbstractJsonType object = fields.get(fieldName);
+        for (Map.Entry<String, AbstractJsonType> entry : fields.entrySet()) {
+            AbstractJsonType object = entry.getValue();
             String lastSign = index == lastIndex ? EMPTY_STRING : NEW_LINE_SIGN;
-            result.append(StringToJsonStringWrapper.wrap(fieldName))
-                  .append(":")
-                  .append(object.toStringJson())
-                  .append(lastSign);
+            result.append(StringToJsonStringWrapper.wrap(entry.getKey()))
+                    .append(":")
+                    .append(object.toStringJson())
+                    .append(lastSign);
             index++;
         }
         result.append(JSON_OBJECT_END);
@@ -69,7 +66,7 @@ public class ObjectJsonType extends AbstractJsonType implements MergableObject<O
 
     @Override
     public void merge(ObjectJsonType mergeWith, PathMetadata currentPathMetadata) {
-        for(String fieldName : mergeWith.fields.keySet()) {
+        for (String fieldName : mergeWith.fields.keySet()) {
             addField(fieldName, mergeWith.getField(fieldName), currentPathMetadata);
         }
     }

--- a/src/main/java/pl/jalokim/propertiestojson/path/PathMetadata.java
+++ b/src/main/java/pl/jalokim/propertiestojson/path/PathMetadata.java
@@ -2,6 +2,7 @@ package pl.jalokim.propertiestojson.path;
 
 import lombok.Data;
 import pl.jalokim.propertiestojson.PropertyArrayHelper;
+import pl.jalokim.propertiestojson.exception.NotLeafValueException;
 import pl.jalokim.propertiestojson.object.AbstractJsonType;
 
 import static pl.jalokim.propertiestojson.Constants.EMPTY_STRING;
@@ -55,7 +56,7 @@ public class PathMetadata {
 
     public void setRawValue(Object rawValue) {
         if (!isLeaf()) {
-            throw new RuntimeException("Cannot set value for not leaf: " + getCurrentFullPath());
+            throw new NotLeafValueException("Cannot set value for not leaf: " + getCurrentFullPath());
         }
         this.rawValue = rawValue;
     }
@@ -79,7 +80,7 @@ public class PathMetadata {
 
     public void setJsonValue(AbstractJsonType jsonValue) {
         if (!isLeaf()) {
-            throw new RuntimeException("Cannot set value for not leaf: " + getCurrentFullPath());
+            throw new NotLeafValueException("Cannot set value for not leaf: " + getCurrentFullPath());
         }
         this.jsonValue = jsonValue;
     }
@@ -91,8 +92,8 @@ public class PathMetadata {
     @Override
     public String toString() {
         return "field='" + fieldName + '\'' +
-               ", rawValue=" + rawValue +
-               ", fullPath='" + getCurrentFullPath() + '}';
+                ", rawValue=" + rawValue +
+                ", fullPath='" + getCurrentFullPath() + '}';
     }
 
     public boolean isArrayField() {

--- a/src/main/java/pl/jalokim/propertiestojson/path/PathMetadataBuilder.java
+++ b/src/main/java/pl/jalokim/propertiestojson/path/PathMetadataBuilder.java
@@ -4,6 +4,9 @@ import static pl.jalokim.propertiestojson.Constants.REGEX_DOT;
 
 public class PathMetadataBuilder {
 
+    private PathMetadataBuilder() {
+    }
+
     public static PathMetadata createRootPathMetaData(String propertyKey) {
         String[] fields = propertyKey.split(REGEX_DOT);
         PathMetadata currentPathMetadata = null;

--- a/src/main/java/pl/jalokim/propertiestojson/resolvers/PrimitiveJsonTypesResolver.java
+++ b/src/main/java/pl/jalokim/propertiestojson/resolvers/PrimitiveJsonTypesResolver.java
@@ -89,7 +89,7 @@ public class PrimitiveJsonTypesResolver extends JsonTypeResolver {
             result = resolversHierarchyResolver.returnConcreteJsonTypeObject(this, propertyValue, propertyKey);
         }
 
-        if(skipNulls && result instanceof JsonNullReferenceType) {
+        if(Boolean.TRUE.equals(skipNulls) && result instanceof JsonNullReferenceType) {
             result = SkipJsonField.SKIP_JSON_FIELD;
         }
 

--- a/src/main/java/pl/jalokim/propertiestojson/resolvers/hierarchy/HierarchyClassResolver.java
+++ b/src/main/java/pl/jalokim/propertiestojson/resolvers/hierarchy/HierarchyClassResolver.java
@@ -12,7 +12,7 @@ import static pl.jalokim.utils.string.StringUtils.concatElementsAsLines;
 
 public class HierarchyClassResolver {
 
-    private final String ERROR_MSG = "Found %s resolvers for instance type: %s%nfound resolvers:%n%s";
+    private static final String ERROR_MSG = "Found %s resolvers for instance type: %s%nfound resolvers:%n%s";
 
     private final List<Class<?>> resolverClasses;
 

--- a/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/ObjectFromTextJsonTypeResolver.java
+++ b/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/ObjectFromTextJsonTypeResolver.java
@@ -5,7 +5,6 @@ import pl.jalokim.propertiestojson.resolvers.PrimitiveJsonTypesResolver;
 import pl.jalokim.propertiestojson.resolvers.primitives.delegator.PrimitiveJsonTypeDelegatorResolver;
 import pl.jalokim.propertiestojson.resolvers.primitives.object.SuperObjectToJsonTypeConverter;
 import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToObjectResolver;
-import pl.jalokim.propertiestojson.resolvers.primitives.utils.JsonObjectHelper;
 import pl.jalokim.propertiestojson.util.PropertiesToJsonConverter;
 
 
@@ -34,13 +33,5 @@ public class ObjectFromTextJsonTypeResolver extends PrimitiveJsonTypeDelegatorRe
      */
     public static AbstractJsonType convertFromObjectToJson(Object propertyValue, String propertyKey) {
         return SuperObjectToJsonTypeConverter.convertFromObjectToJson(propertyValue, propertyKey);
-    }
-
-    public static boolean isValidJsonObjectOrArray(String propertyValue) {
-        return JsonObjectHelper.isValidJsonObjectOrArray(propertyValue);
-    }
-
-    private static boolean hasJsonObjectSignature(String propertyValue) {
-        return JsonObjectHelper.hasJsonObjectSignature(propertyValue);
     }
 }

--- a/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/string/TextToEmptyStringResolver.java
+++ b/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/string/TextToEmptyStringResolver.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 public class TextToEmptyStringResolver implements TextToConcreteObjectResolver<String> {
 
     public static final TextToEmptyStringResolver EMPTY_TEXT_RESOLVER = new TextToEmptyStringResolver();
-    private final static String EMPTY_VALUE = "";
+    private static final String EMPTY_VALUE = "";
 
     @Override
     public Optional<String> returnObjectWhenCanBeResolved(PrimitiveJsonTypesResolver primitiveJsonTypesResolver,

--- a/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/string/TextToJsonNullReferenceResolver.java
+++ b/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/string/TextToJsonNullReferenceResolver.java
@@ -9,7 +9,7 @@ import static pl.jalokim.propertiestojson.object.JsonNullReferenceType.NULL_VALU
 
 public class TextToJsonNullReferenceResolver implements TextToConcreteObjectResolver<Object> {
 
-    public final static TextToJsonNullReferenceResolver TEXT_TO_NULL_JSON_RESOLVER = new TextToJsonNullReferenceResolver();
+    public static final TextToJsonNullReferenceResolver TEXT_TO_NULL_JSON_RESOLVER = new TextToJsonNullReferenceResolver();
 
     @Override
     public Optional<Object> returnObjectWhenCanBeResolved(PrimitiveJsonTypesResolver primitiveJsonTypesResolver, String propertyValue, String propertyKey) {

--- a/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/string/TextToNumberResolver.java
+++ b/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/string/TextToNumberResolver.java
@@ -26,10 +26,12 @@ public class TextToNumberResolver implements TextToConcreteObjectResolver<Number
         try {
             return getIntegerNumber(propertyValue);
         } catch (NumberFormatException exc) {
+            // NOTHING TO DO
         }
         try {
             return getDoubleNumber(propertyValue);
         } catch (NumberFormatException exc) {
+            // NOTHING TO DO
         }
         return null;
     }

--- a/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/utils/JsonObjectHelper.java
+++ b/src/main/java/pl/jalokim/propertiestojson/resolvers/primitives/utils/JsonObjectHelper.java
@@ -50,6 +50,9 @@ public class JsonObjectHelper {
         primitiveJsonTypesResolver = new PrimitiveJsonTypesResolver(toObjectsResolvers, toJsonResolvers, false, NULL_TO_JSON_RESOLVER);
     }
 
+    private JsonObjectHelper() {
+    }
+
     public static String toJson(Object object) {
         return gson.toJson(object);
     }

--- a/src/main/java/pl/jalokim/propertiestojson/util/PropertiesToJsonConverter.java
+++ b/src/main/java/pl/jalokim/propertiestojson/util/PropertiesToJsonConverter.java
@@ -45,7 +45,7 @@ import static pl.jalokim.propertiestojson.util.PropertiesToJsonConverterBuilder.
 import static pl.jalokim.propertiestojson.util.PropertiesToJsonConverterBuilder.TO_OBJECT_RESOLVERS;
 import static pl.jalokim.propertiestojson.util.exception.ParsePropertiesException.PROPERTY_KEY_NEEDS_TO_BE_STRING_TYPE;
 import static pl.jalokim.propertiestojson.util.exception.ParsePropertiesException.STRING_RESOLVER_AS_NOT_LAST;
-import static pl.jalokim.propertiestojson.util.exception.ParsePropertiesException.STRING__TO_JSON_RESOLVER_AS_NOT_LAST;
+import static pl.jalokim.propertiestojson.util.exception.ParsePropertiesException.STRING_TO_JSON_RESOLVER_AS_NOT_LAST;
 
 public final class PropertiesToJsonConverter {
 
@@ -186,7 +186,7 @@ public final class PropertiesToJsonConverter {
      * @throws ReadInputException       when cannot find file
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertPropertiesFromFileToJson(String pathToFile) throws ReadInputException, ParsePropertiesException {
+    public String convertPropertiesFromFileToJson(String pathToFile) {
         return convertPropertiesFromFileToJson(new File(pathToFile));
     }
 
@@ -216,7 +216,7 @@ public final class PropertiesToJsonConverter {
      * @throws ReadInputException       when cannot find file
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertPropertiesFromFileToJson(String pathToFile, String... includeDomainKeys) throws ReadInputException, ParsePropertiesException {
+    public String convertPropertiesFromFileToJson(String pathToFile, String... includeDomainKeys) {
         return convertPropertiesFromFileToJson(new File(pathToFile), includeDomainKeys);
     }
 
@@ -239,7 +239,7 @@ public final class PropertiesToJsonConverter {
      * @throws ReadInputException       when cannot find file
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertPropertiesFromFileToJson(File file) throws ReadInputException, ParsePropertiesException {
+    public String convertPropertiesFromFileToJson(File file) {
         try {
             InputStream targetStream = new FileInputStream(file);
             return convertToJson(targetStream);
@@ -274,7 +274,7 @@ public final class PropertiesToJsonConverter {
      * @throws ReadInputException       when cannot find file
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertPropertiesFromFileToJson(File file, String... includeDomainKeys) throws ReadInputException, ParsePropertiesException {
+    public String convertPropertiesFromFileToJson(File file, String... includeDomainKeys) {
         try {
             InputStream targetStream = new FileInputStream(file);
             return convertToJson(targetStream, includeDomainKeys);
@@ -302,7 +302,7 @@ public final class PropertiesToJsonConverter {
      * @throws ReadInputException       when cannot find file
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertToJson(InputStream inputStream) throws ReadInputException, ParsePropertiesException {
+    public String convertToJson(InputStream inputStream) {
         return convertToJson(inputStreamToProperties(inputStream));
     }
 
@@ -332,7 +332,7 @@ public final class PropertiesToJsonConverter {
      * @throws ReadInputException       when cannot find file
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertToJson(InputStream inputStream, String... includeDomainKeys) throws ReadInputException, ParsePropertiesException {
+    public String convertToJson(InputStream inputStream, String... includeDomainKeys) {
         return convertToJson(inputStreamToProperties(inputStream), includeDomainKeys);
     }
 
@@ -351,7 +351,7 @@ public final class PropertiesToJsonConverter {
      * @return simple String with json
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertToJson(Properties properties) throws ParsePropertiesException {
+    public String convertToJson(Properties properties) {
         for(Map.Entry<Object, Object> entry : properties.entrySet()) {
             if(!(entry.getKey() instanceof String)) {
                 throw new ParsePropertiesException(format(PROPERTY_KEY_NEEDS_TO_BE_STRING_TYPE,
@@ -384,7 +384,7 @@ public final class PropertiesToJsonConverter {
      * @return Simple String with json
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertToJson(Properties properties, String... includeDomainKeys) throws ParsePropertiesException {
+    public String convertToJson(Properties properties, String... includeDomainKeys) {
         return convertFromValuesAsObjectMap(propertiesToMap(properties), includeDomainKeys);
     }
 
@@ -407,7 +407,7 @@ public final class PropertiesToJsonConverter {
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
 
-    public String convertToJson(Map<String, String> properties) throws ParsePropertiesException {
+    public String convertToJson(Map<String, String> properties) {
         return convertFromValuesAsObjectMap(stringValueMapToObjectValueMap(properties));
 
     }
@@ -438,7 +438,7 @@ public final class PropertiesToJsonConverter {
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
 
-    public String convertToJson(Map<String, String> properties, String... includeDomainKeys) throws ParsePropertiesException {
+    public String convertToJson(Map<String, String> properties, String... includeDomainKeys) {
         return convertFromValuesAsObjectMap(stringValueMapToObjectValueMap(properties), includeDomainKeys);
     }
 
@@ -458,7 +458,7 @@ public final class PropertiesToJsonConverter {
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
 
-    public String convertFromValuesAsObjectMap(Map<String, Object> properties) throws ParsePropertiesException {
+    public String convertFromValuesAsObjectMap(Map<String, Object> properties) {
         ObjectJsonType coreObjectJsonType = new ObjectJsonType();
         for(String propertyKey : getAllKeysFromProperties(properties)) {
             addFieldsToJsonObject(properties, coreObjectJsonType, propertyKey);
@@ -498,7 +498,7 @@ public final class PropertiesToJsonConverter {
      * @return simple String with json
      * @throws ParsePropertiesException when structure of properties is not compatible with json structure
      */
-    public String convertFromValuesAsObjectMap(Map<String, Object> properties, String... includeDomainKeys) throws ParsePropertiesException {
+    public String convertFromValuesAsObjectMap(Map<String, Object> properties, String... includeDomainKeys) {
         Map<String, Object> filteredProperties = new HashMap<>();
         for(String key : properties.keySet()) {
             for(String requiredKey : includeDomainKeys) {
@@ -526,13 +526,10 @@ public final class PropertiesToJsonConverter {
 
     private static boolean keyIsCompatibleWithRequiredKey(String requiredKey, String key) {
         String testedChar = key.substring(requiredKey.length(), requiredKey.length() + 1);
-        if(testedChar.equals(ARRAY_START_SIGN) || testedChar.equals(".")) {
-            return true;
-        }
-        return false;
+        return testedChar.equals(ARRAY_START_SIGN) || testedChar.equals(".");
     }
 
-    private Properties inputStreamToProperties(InputStream inputStream) throws ReadInputException {
+    private Properties inputStreamToProperties(InputStream inputStream) {
         Properties propertiesWithConvertedValues = new Properties();
         Properties properties = new Properties();
         try {
@@ -601,7 +598,7 @@ public final class PropertiesToJsonConverter {
         if(containStringResolverType) {
             ObjectToJsonTypeConverter<?> lastResolver = resolvers.get(resolvers.size() - 1);
             if(!(lastResolver.getClass().equals(StringToJsonTypeConverter.class))) {
-                throw new ParsePropertiesException(STRING__TO_JSON_RESOLVER_AS_NOT_LAST);
+                throw new ParsePropertiesException(STRING_TO_JSON_RESOLVER_AS_NOT_LAST);
             }
         }
     }

--- a/src/main/java/pl/jalokim/propertiestojson/util/PropertiesToJsonConverterBuilder.java
+++ b/src/main/java/pl/jalokim/propertiestojson/util/PropertiesToJsonConverterBuilder.java
@@ -1,22 +1,10 @@
 package pl.jalokim.propertiestojson.util;
 
 import pl.jalokim.propertiestojson.object.AbstractJsonType;
-import pl.jalokim.propertiestojson.resolvers.primitives.object.BooleanToJsonTypeConverter;
-import pl.jalokim.propertiestojson.resolvers.primitives.object.CharacterToJsonTypeConverter;
-import pl.jalokim.propertiestojson.resolvers.primitives.object.ElementsToJsonTypeConverter;
-import pl.jalokim.propertiestojson.resolvers.primitives.object.NullToJsonTypeConverter;
-import pl.jalokim.propertiestojson.resolvers.primitives.object.NumberToJsonTypeConverter;
-import pl.jalokim.propertiestojson.resolvers.primitives.object.ObjectToJsonTypeConverter;
-import pl.jalokim.propertiestojson.resolvers.primitives.object.SuperObjectToJsonTypeConverter;
-import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToBooleanResolver;
-import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToCharacterResolver;
-import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToConcreteObjectResolver;
-import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToElementsResolver;
-import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToEmptyStringResolver;
-import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToJsonNullReferenceResolver;
-import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToNumberResolver;
-import pl.jalokim.propertiestojson.resolvers.primitives.string.TextToObjectResolver;
+import pl.jalokim.propertiestojson.resolvers.primitives.object.*;
+import pl.jalokim.propertiestojson.resolvers.primitives.string.*;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,6 +21,7 @@ public class PropertiesToJsonConverterBuilder {
 
     static final List<TextToConcreteObjectResolver> TO_OBJECT_RESOLVERS = defaultResolvers();
     static final List<ObjectToJsonTypeConverter> TO_JSON_TYPE_CONVERTERS = defaultConverters();
+    private Charset charset;
 
     /**
      * Default list of resolvers from text to java Object...
@@ -168,6 +157,17 @@ public class PropertiesToJsonConverterBuilder {
     }
 
     /**
+     * It will set the charset of the reader.
+     *
+     * @param charset charset to use
+     * @return builder instance
+     */
+    public PropertiesToJsonConverterBuilder charset(Charset charset) {
+        this.charset = charset;
+        return this;
+    }
+
+    /**
      * It will skip every leaf in json object which is null, not skip null in arrays.
      *
      * @return PropertiesToJsonConverterBuilder instance
@@ -184,7 +184,7 @@ public class PropertiesToJsonConverterBuilder {
      */
     public PropertiesToJsonConverter build() {
         List<ObjectToJsonTypeConverter> resultConverters = new ArrayList<>();
-        if(onlyCustomConverters) {
+        if (onlyCustomConverters) {
             resultConverters.addAll(converters);
         } else {
             resultConverters.addAll(converters);
@@ -192,7 +192,7 @@ public class PropertiesToJsonConverterBuilder {
         }
 
         List<TextToConcreteObjectResolver> resultResolvers = new ArrayList<>();
-        if(onlyCustomResolvers) {
+        if (onlyCustomResolvers) {
             resultResolvers.addAll(resolvers);
         } else {
             resultResolvers.addAll(resolvers);
@@ -200,10 +200,11 @@ public class PropertiesToJsonConverterBuilder {
         }
 
         return new PropertiesToJsonConverter(resultResolvers,
-                                             resultConverters,
-                                             nullToJsonConverter,
-                                             textToJsonNullResolver,
-                                             textToEmptyStringResolver,
-                                             skipNul);
+                resultConverters,
+                nullToJsonConverter,
+                textToJsonNullResolver,
+                textToEmptyStringResolver,
+                skipNul,
+                charset);
     }
 }

--- a/src/main/java/pl/jalokim/propertiestojson/util/StringToJsonStringWrapper.java
+++ b/src/main/java/pl/jalokim/propertiestojson/util/StringToJsonStringWrapper.java
@@ -2,6 +2,9 @@ package pl.jalokim.propertiestojson.util;
 
 public class StringToJsonStringWrapper {
 
+    private StringToJsonStringWrapper() {
+    }
+
     private static final String JSON_STRING_SCHEMA = "\"%s\"";
 
     public static String wrap(String textToWrap) {

--- a/src/main/java/pl/jalokim/propertiestojson/util/exception/ParsePropertiesException.java
+++ b/src/main/java/pl/jalokim/propertiestojson/util/exception/ParsePropertiesException.java
@@ -8,7 +8,7 @@ public class ParsePropertiesException extends RuntimeException {
     public static final String STRING_RESOLVER_AS_NOT_LAST = "Added some type resolver after " + StringJsonTypeResolver.class.getCanonicalName() +
                                                              ". This type resolver always should be last when is in configuration of resolvers";
 
-    public static final String STRING__TO_JSON_RESOLVER_AS_NOT_LAST = "Added some type resolver after " + StringToJsonTypeConverter.class.getCanonicalName() +
+    public static final String STRING_TO_JSON_RESOLVER_AS_NOT_LAST = "Added some type resolver after " + StringToJsonTypeConverter.class.getCanonicalName() +
                                                                       ". This type resolver always should be last when is in configuration of resolvers";
 
     public static final String PROPERTY_KEY_NEEDS_TO_BE_STRING_TYPE = "Unsupported property key type: %s for key: %s, Property key needs to be a string type";

--- a/src/test/java/pl/jalokim/propertiestojson/util/PropertiesToJsonConverterEncodingTest.java
+++ b/src/test/java/pl/jalokim/propertiestojson/util/PropertiesToJsonConverterEncodingTest.java
@@ -1,0 +1,24 @@
+package pl.jalokim.propertiestojson.util;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import pl.jalokim.propertiestojson.util.PropertiesToJsonConverterBuilder;
+
+import java.nio.charset.StandardCharsets;
+
+public class PropertiesToJsonConverterEncodingTest {
+
+    @Test
+    public void shouldManageChineseCharacters() {
+        String json = PropertiesToJsonConverterBuilder.builder().charset(StandardCharsets.UTF_8).build()
+                .convertPropertiesFromFileToJson("src/test/resources/encoding/messages_zh_TW.properties");
+        Assertions.assertThat(json).contains("我接受使用條款");
+    }
+
+    @Test
+    public void shouldNotManageChineseCharactersDueToDifferentEncoding() {
+        String json = PropertiesToJsonConverterBuilder.builder().charset(StandardCharsets.ISO_8859_1).build()
+                .convertPropertiesFromFileToJson("src/test/resources/encoding/messages_zh_TW.properties");
+        Assertions.assertThat(json).doesNotContain("我接受使用條款");
+    }
+}

--- a/src/test/resources/encoding/messages_zh_TW.properties
+++ b/src/test/resources/encoding/messages_zh_TW.properties
@@ -1,0 +1,1 @@
+accettoCondizioni=我接受使用條款


### PR DESCRIPTION
Before the modification the only used encoding was the default one (kept from the default jvm).
Now the user can specify which encoding to use.

In my case this was helpful in order to read properties files with chinese characters.

Finally I've tried to apply the boy scout rule, by making modification driven by sonarqube.

Hope to be helpful